### PR TITLE
Fix brackets for 1.0.0-beta3

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -109,7 +109,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% if @graphite_options.is_a?(Hash) -%>
 [[graphite]]
 <% @graphite_options.keys.sort.each do |key| -%>
-<% val = @graphite_options[key] 
+<% val = @graphite_options[key]
   if key == 'templates' and val.is_a?(Array) -%>
   templates = [
   <%- val.each do |template| -%>
@@ -126,7 +126,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% @graphite_options.each do |option| -%>
 [[graphite]]
 <% @options.key.sort.each do |key| -%>
-<% val = @options[key] 
+<% val = @options[key]
   if key == 'templates' and val.is_a?(Array) -%>
   templates = [
   <%- val.each do |template| -%>
@@ -148,7 +148,7 @@ reporting-disabled = <%= @reporting_disabled %>
 
 <% if @collectd_options and ! @collectd_options.empty? -%>
 <% if @collectd_options.is_a?(Hash) -%>
-[collectd]
+[[collectd]]
 <% @collectd_options.keys.sort.each do |key| -%>
 <% val = @collectd_options[key] 
   if val =~ /^(true|false|[0-9]+)$/ or val.is_a?(TrueClass) or val.is_a?(FalseClass) or val.is_a?(Fixnum) -%>
@@ -159,7 +159,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% end -%>
 <% elsif @collectd_options.is_a?(Array) -%>
 <% @collectd_options.each do |option| -%>
-[collectd]
+[[collectd]]
 <% option.keys.sort.each do |key| -%>
 <% val = @option[key] 
   if val =~ /^(true|false|[0-9]+)$/ or val.is_a?(TrueClass) or val.is_a?(FalseClass) or val.is_a?(Fixnum) -%>
@@ -171,15 +171,15 @@ reporting-disabled = <%= @reporting_disabled %>
 <% end -%>
 <% end -%>
 <% else -%>
-[collectd]
+[[collectd]]
   enabled = false
 <% end -%>
 
 <% if @opentsdb_options and ! @opentsdb_options.empty? -%>
 <% if @opentsdb_options.is_a?(Hash) -%>
-[opentsdb]
-<% @opentsdb_options.keys.sort.each do |key| 
-   val = @opentsdb_options[key] 
+[[opentsdb]]
+<% @opentsdb_options.keys.sort.each do |key|
+   val = @opentsdb_options[key]
   -%>
 <% if val =~ /^(true|false|[0-9]+)$/ or val.is_a?(TrueClass) or val.is_a?(FalseClass) or val.is_a?(Fixnum) -%>
   <%=key %> = <%=val %>
@@ -189,7 +189,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% end -%>
 <% elsif @opentsdb_options.is_a?(Array) -%>
 <% @opentsdb_options.each do |option| -%>
-[opentsdb]
+[[opentsdb]]
 <% option.keys.sort.each do |key|
    val = @option[key]
   -%>
@@ -202,14 +202,14 @@ reporting-disabled = <%= @reporting_disabled %>
 <% end -%>
 <% end -%>
 <% else -%>
-[opentsdb]
+[[opentsdb]]
   enabled = false
 <% end -%>
 
 <% if @udp_options and ! @udp_options.empty? -%>
 <% if @udp_options.is_a?(Hash) -%>
 [[udp]]
-<% @udp_options.keys.sort.each do |key| 
+<% @udp_options.keys.sort.each do |key|
    val =  @udp_options[key]
    -%>
 <% if val =~ /^(true|false|[0-9]+)$/ or val.is_a?(TrueClass) or val.is_a?(FalseClass) or val.is_a?(Fixnum) -%>
@@ -221,7 +221,7 @@ reporting-disabled = <%= @reporting_disabled %>
 <% elsif @udp_options.is_a?(Array) -%>
 <% @udp_options.each do |option| -%>
 [[udp]]
-<% option.keys.sort.each do |key| 
+<% option.keys.sort.each do |key|
  val = option[key]
   -%>
 <% if val =~ /^(true|false|[0-9]+)$/ or val.is_a?(TrueClass) or val.is_a?(FalseClass) or val.is_a?(Fixnum) -%>


### PR DESCRIPTION
1.0.0-beta3 complains about the missing extra backets for:
- run.Config.opentsdb
- run.Config.collectd

This adds these so Influx can still be started correctly.

Also remove extra white space on a few lines
