### PR TITLE
Fixed template, add missing options to manifests

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class influxdb::params {
   $compact_min_file_count                       = undef
   $compact_full_write_cold_duration             = undef
   $max_points_per_block                         = undef
+  $max_connection_limit                         = undef
 
   $hinted_handoff_enabled                       = true
   $hinted_handoff_dir                           = '/var/lib/influxdb/hh'
@@ -53,6 +54,10 @@ class influxdb::params {
 
   $shard_writer_timeout                         = '5s'
   $cluster_write_timeout                        = '10s'
+  $max_concurrent_queries                       = undef
+  $query_timeout                                = undef
+  $log_queries_after                            = undef
+  $max_select_series                            = undef
 
   $retention_enabled                            = true
   $retention_check_interval                     = '30m'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,6 +42,7 @@ class influxdb::server (
   $compact_min_file_count                       = $influxdb::params::compact_min_file_count,
   $compact_full_write_cold_duration             = $influxdb::params::compact_full_write_cold_duration,
   $max_points_per_block                         = $influxdb::params::max_points_per_block,
+  $max_connection_limit                         = $influxdb::params::max_connection_limit,
 
   $hinted_handoff_enabled                       = $influxdb::params::hinted_handoff_enabled,
   $hinted_handoff_dir                           = $influxdb::params::hinted_handoff_dir,
@@ -54,6 +55,10 @@ class influxdb::server (
 
   $shard_writer_timeout                         = $influxdb::params::shard_writer_timeout,
   $cluster_write_timeout                        = $influxdb::params::cluster_write_timeout,
+  $max_concurrent_queries                       = $influxdb::params::max_concurrent_queries,
+  $query_timeout                                = $influxdb::params::query_timeout,
+  $log_queries_after                            = $influxdb::params::log_queries_after,
+  $max_select_series                            = $influxdb::params::max_select_series,
 
   $retention_enabled                            = $influxdb::params::retention_enabled,
   $retention_check_interval                     = $influxdb::params::retention_check_interval,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -45,6 +45,7 @@ class influxdb::server::config {
   $compact_min_file_count                       = $influxdb::server::compact_min_file_count
   $compact_full_write_cold_duration             = $influxdb::server::compact_full_write_cold_duration
   $max_points_per_block                         = $influxdb::server::max_points_per_block
+  $max_connection_limit                         = $influxdb::server::max_connection_limit
 
   $hinted_handoff_enabled                       = $influxdb::server::hinted_handoff_enabled
   $hinted_handoff_dir                           = $influxdb::server::hinted_handoff_dir
@@ -57,6 +58,10 @@ class influxdb::server::config {
 
   $shard_writer_timeout                         = $influxdb::server::shard_writer_timeout
   $cluster_write_timeout                        = $influxdb::server::cluster_write_timeout
+  $max_concurrent_queries                       = $influxdb::server::max_concurrent_queries
+  $query_timeout                                = $influxdb::server::query_timeout
+  $log_queries_after                            = $influxdb::server::log_queries_after
+  $max_select_series                            = $influxdb::server::max_select_series
 
   $retention_enabled                            = $influxdb::server::retention_enabled
   $retention_check_interval                     = $influxdb::server::retention_check_interval

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -75,18 +75,18 @@ max-series-per-database = 0
 [coordinator]
   shard-writer-timeout = "<%= @shard_writer_timeout %>"
   write-timeout = "<%= @cluster_write_timeout %>"
-<% if @max_concurrent_queries %>
-  max-concurrent-queries = "<%= @max_concurrent_queries %>"
-<% end %>
-<% if @query_timeout %>
+<% if @max_concurrent_queries -%>
+  max-concurrent-queries = <%= @max_concurrent_queries %>
+<% end -%>
+<% if @query_timeout -%>
   query-timeout = "<%= @query_timeout %>"
-<% end %>
-<% if @log_queries_after %>
+<% end -%>
+<% if @log_queries_after -%>
   log-queries-after = "<%= @log_queries_after %>"
-<% end %>
-<% if @max_select_series %>
+<% end -%>
+<% if @max_select_series -%>
   max-select-series = <%= @max_select_series %>
-<% end %>
+<% end -%>
 
 [retention]
   enabled = <%= @retention_enabled %>
@@ -117,9 +117,9 @@ max-series-per-database = 0
   pprof-enabled = <%= @http_pprof_enabled %>
   https-enabled = <%= @http_https_enabled %>
   https-certificate = "<%= @http_https_certificate %>"
-<% if @max_connection_limit %>
+<% if @max_connection_limit -%>
   max-connection-limit = <%= @max_connection_limit %>
-<% end %>
+<% end -%>
 
 <% if @graphite_options and ! @graphite_options.empty? -%>
 <% if @graphite_options.is_a?(Hash) -%>


### PR DESCRIPTION
The new configuration options where missed being added to the puppet
files.  Correctly fix this to ensure we can use the module within 1.0
and later.
Fixed the template from having quotes around a int which blew up
influxdb.
Stripped down the blank lines on the config file to be a little bit more
neater
