### PR TITLE
Readd shard_writer_timeout

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,7 @@ class influxdb::params {
   $hinted_handoff_retry_max_interval            = '1m'
   $hinted_handoff_purge_interval                = '1h'
 
+  $shard_writer_timeout                         = '5s'
   $cluster_write_timeout                        = '10s'
   $max_concurrent_queries                       = undef
   $query_timeout                                = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,6 +51,7 @@ class influxdb::server (
   $hinted_handoff_retry_max_interval            = $influxdb::params::hinted_handoff_retry_max_interval,
   $hinted_handoff_purge_interval                = $influxdb::params::hinted_handoff_purge_interval,
 
+  $shard_writer_timeout                         = $influxdb::params::shard_writer_timeout,
   $cluster_write_timeout                        = $influxdb::params::cluster_write_timeout,
   $max_concurrent_queries                       = $influxdb::params::max_concurrent_queries,
   $query_timeout                                = $influxdb::params::query_timeout,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -54,6 +54,7 @@ class influxdb::server::config {
   $hinted_handoff_retry_max_interval            = $influxdb::server::hinted_handoff_retry_max_interval
   $hinted_handoff_purge_interval                = $influxdb::server::hinted_handoff_purge_interval
 
+  $shard_writer_timeout                         = $influxdb::server::shard_writer_timeout
   $cluster_write_timeout                        = $influxdb::server::cluster_write_timeout
   $max_concurrent_queries                       = $influxdb::server::max_concurrent_queries
   $query_timeout                                = $influxdb::server::query_timeout


### PR DESCRIPTION
- Re-add the shard_writer_timeout which seems to have been removed
  inadvertently.
- TEST:
  - Successfully started up vagrant instance.
  - Compared generated influx config with version from multiplay fork
    before merging with upstream.
